### PR TITLE
feat(auth): Swagger 기반 로그인/회원가입/토큰 관리 구현 (#4, #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE_URL=https://api.ninewinit.store
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error);
+    }
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      <h2 className="text-2xl font-bold">문제가 발생했습니다</h2>
+      <p className="text-sm text-muted-foreground">
+        잠시 후 다시 시도하거나, 문제가 계속되면 관리자에게 문의해주세요.
+      </p>
+      {process.env.NODE_ENV !== "production" && (
+        <pre className="max-w-2xl overflow-x-auto rounded bg-gray-100 p-3 text-left text-xs">
+          {error.message}
+          {error.digest ? `\n\ndigest: ${error.digest}` : ""}
+        </pre>
+      )}
+      <div className="flex gap-2">
+        <Button onClick={() => reset()}>다시 시도</Button>
+        <Button variant="outline" asChild>
+          <Link href="/">홈으로</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/intro/page.tsx
+++ b/app/intro/page.tsx
@@ -1,9 +1,16 @@
+import type { Metadata } from "next";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import intro1 from "@/public/info1.png";
 import intro2 from "@/public/info2.png";
 import intro3 from "@/public/info3.png";
 import intro4 from "@/public/info4.png";
+
+export const metadata: Metadata = {
+  title: "서비스 소개 | 나인위닛",
+  description: "나인위닛의 스마트스토어 SEO 분석 및 광고 최적화 서비스 소개",
+};
+
 export default function intro() {
   const introImages = [intro1, intro2, intro3, intro4];
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ export const metadata: Metadata = {
   title: "나인위닛 - 스마트스토어 SEO 최적화 솔루션",
   description: "데이터 기반 스마트스토어 SEO 분석 및 광고 최적화 서비스. 매출 성장을 위한 전문 솔루션을 제공합니다.",
   keywords: "스마트스토어, SEO, 네이버쇼핑, 광고최적화, 키워드분석",
-    generator: 'v0.dev'
 }
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
+import { Providers } from "./providers"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -19,7 +20,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   )
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,3 +1,11 @@
 export default function Loading() {
-  return null
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div
+        role="status"
+        aria-label="페이지를 불러오는 중"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-transparent"
+      />
+    </div>
+  );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
 import UserProfile from "@/components/mypage/user-profile";
 import MypageMenu from "@/components/mypage/mypage-menu";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { RouteGuard } from "@/components/auth/route-guard";
+
+export const metadata: Metadata = {
+  title: "마이페이지 | 나인위닛",
+  robots: { index: false, follow: false },
+};
 
 export default function Mypage() {
   return (

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -2,9 +2,11 @@ import UserProfile from "@/components/mypage/user-profile";
 import MypageMenu from "@/components/mypage/mypage-menu";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
+import { RouteGuard } from "@/components/auth/route-guard";
+
 export default function Mypage() {
   return (
-    <>
+    <RouteGuard>
       <Header />
       <div className="container mx-auto py-8 min-h-screen">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
@@ -17,6 +19,6 @@ export default function Mypage() {
         </div>
       </div>
       <Footer />
-    </>
+    </RouteGuard>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      <p className="text-sm font-medium text-muted-foreground">404</p>
+      <h2 className="text-2xl font-bold">페이지를 찾을 수 없습니다</h2>
+      <p className="text-sm text-muted-foreground">
+        요청하신 페이지가 이동되었거나 더 이상 존재하지 않습니다.
+      </p>
+      <Button asChild>
+        <Link href="/">홈으로 돌아가기</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import { Toaster } from "sonner";
+import { setUnauthorizedHandler } from "@/lib/api-client";
+import { useAuthStore } from "@/stores/auth-store";
+
+const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30 * 1000,
+            retry: 1,
+            refetchOnWindowFocus: false,
+          },
+          mutations: { retry: 0 },
+        },
+      }),
+  );
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      useAuthStore.getState().clearSession();
+    });
+  }, []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+        {children}
+        <Toaster position="top-center" richColors closeButton />
+      </GoogleOAuthProvider>
+    </QueryClientProvider>
+  );
+}

--- a/components/auth/google-login-button.tsx
+++ b/components/auth/google-login-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useGoogleLogin } from "@react-oauth/google";
+import { Button } from "@/components/ui/button";
+import { useGoogleLoginMutation } from "@/hooks/use-auth";
+import { toast } from "sonner";
+
+type GoogleLoginButtonProps = {
+  label?: string;
+  onSuccess?: () => void;
+};
+
+export function GoogleLoginButton({
+  label = "Google 로그인",
+  onSuccess,
+}: GoogleLoginButtonProps) {
+  const googleMutation = useGoogleLoginMutation();
+
+  const login = useGoogleLogin({
+    flow: "implicit",
+    onSuccess: async (tokenResponse) => {
+      const idToken =
+        (tokenResponse as unknown as { id_token?: string }).id_token ??
+        tokenResponse.access_token;
+      if (!idToken) {
+        toast.error("Google 토큰을 가져오지 못했습니다.");
+        return;
+      }
+      googleMutation.mutate(idToken, {
+        onSuccess: () => onSuccess?.(),
+      });
+    },
+    onError: () => toast.error("Google 인증이 취소되었습니다."),
+  });
+
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+  const disabled = !clientId || googleMutation.isPending;
+
+  return (
+    <Button
+      variant="outline"
+      className="w-full"
+      type="button"
+      disabled={disabled}
+      onClick={() => login()}
+      title={!clientId ? "NEXT_PUBLIC_GOOGLE_CLIENT_ID 미설정" : undefined}
+    >
+      {googleMutation.isPending ? "처리 중..." : label}
+    </Button>
+  );
+}

--- a/components/auth/route-guard.tsx
+++ b/components/auth/route-guard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/stores/auth-store";
+
+type RouteGuardProps = {
+  children: React.ReactNode;
+  redirectTo?: string;
+};
+
+export function RouteGuard({ children, redirectTo = "/" }: RouteGuardProps) {
+  const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  useEffect(() => {
+    const unsub = useAuthStore.persist.onFinishHydration(() => {
+      setHasHydrated(true);
+    });
+    if (useAuthStore.persist.hasHydrated()) setHasHydrated(true);
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (hasHydrated && !accessToken) {
+      router.replace(redirectTo);
+    }
+  }, [hasHydrated, accessToken, redirectTo, router]);
+
+  if (!hasHydrated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!accessToken) return null;
+
+  return <>{children}</>;
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,6 @@
 import Logo from "@/public/Logo_Main.png";
+import { COMPANY_INFO } from "@/config/company";
+
 export const Footer = () => {
   return (
     <footer className="bg-black text-white py-8 px-6 mt-16">
@@ -6,21 +8,21 @@ export const Footer = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           <div>
             <div className="flex items-center space-x-2 mb-4">
-              <img src={Logo.src} alt="나인위닛 로고" />
+              <img src={Logo.src} alt={`${COMPANY_INFO.name} 로고`} />
             </div>
-            <p className="text-gray-400">스마트스토어 SEO 최적화 전문 서비스</p>
-            <p>서비스 데이터 분석 기반 매출 최적화 전문</p>
+            <p className="text-gray-400">{COMPANY_INFO.tagline}</p>
+            <p>{COMPANY_INFO.subTagline}</p>
           </div>
           <div className="space-y-2 text-sm text-gray-400">
-            <p>주소: 주소 수원시 세류동 482-7 501호</p>
-            <p>전화: 010-4590-4917</p>
-            <p>이메일:9winit01@gmail.com</p>
-            <p>사업자번호: 246-17-02470</p>
-            <p>대표: 배대근</p>
+            <p>주소: {COMPANY_INFO.address}</p>
+            <p>전화: {COMPANY_INFO.phone}</p>
+            <p>이메일: {COMPANY_INFO.email}</p>
+            <p>사업자번호: {COMPANY_INFO.businessNumber}</p>
+            <p>대표: {COMPANY_INFO.ceo}</p>
           </div>
         </div>
         <div className="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-          <p>&copy; 2024 나인위닛. All rights reserved.</p>
+          <p>&copy; {COMPANY_INFO.copyrightYear} {COMPANY_INFO.name}. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -19,6 +19,8 @@ export const Header = () => {
       <div className="max-w-7xl mx-auto flex flex-col lg:flex-row justify-between items-center space-y-4 lg:space-y-0">
         <div className="flex items-center space-x-2">
           <button
+            type="button"
+            aria-label="홈으로 이동"
             onClick={() => {
               router.push("/");
             }}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -5,11 +5,15 @@ import { ProModal } from "@/components/modal/pro-modal";
 import { AuthModal } from "@/components/modal/auth-modal";
 import { useRouter, useSearchParams } from "next/navigation";
 import mainLogo from "@/public/Logo_Main.png";
+import { useAuthStore } from "@/stores/auth-store";
+import { useLogoutMutation } from "@/hooks/use-auth";
 export const Header = () => {
   const [showMembership, setShowMembership] = useState(false);
   const [showAuth, setShowAuth] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isAuthenticated = useAuthStore((state) => Boolean(state.accessToken));
+  const logout = useLogoutMutation();
   return (
     <header className="sticky top-0 z-50 bg-black text-white py-4 px-6">
       <div className="max-w-7xl mx-auto flex flex-col lg:flex-row justify-between items-center space-y-4 lg:space-y-0">
@@ -37,12 +41,26 @@ export const Header = () => {
           >
             PRO가입
           </button>
-          <button
-            onClick={() => setShowAuth(true)}
-            className="hover:text-gray-300 transition-colors"
-          >
-            로그인
-          </button>
+          {isAuthenticated ? (
+            <button
+              onClick={() =>
+                logout.mutate(undefined, {
+                  onSettled: () => router.replace("/"),
+                })
+              }
+              className="hover:text-gray-300 transition-colors"
+              disabled={logout.isPending}
+            >
+              {logout.isPending ? "로그아웃 중..." : "로그아웃"}
+            </button>
+          ) : (
+            <button
+              onClick={() => setShowAuth(true)}
+              className="hover:text-gray-300 transition-colors"
+            >
+              로그인
+            </button>
+          )}
           <button
             onClick={() => {
               router.push("mypage", { scroll: false });

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,19 +1,33 @@
 "use client";
 
-import { useState } from "react";
 import { ProModal } from "@/components/modal/pro-modal";
 import { AuthModal } from "@/components/modal/auth-modal";
 import { useRouter, useSearchParams } from "next/navigation";
 import mainLogo from "@/public/Logo_Main.png";
 import { useAuthStore } from "@/stores/auth-store";
 import { useLogoutMutation } from "@/hooks/use-auth";
+import { useUIStore } from "@/stores/ui-store";
+import { COMPANY_INFO } from "@/config/company";
+
 export const Header = () => {
-  const [showMembership, setShowMembership] = useState(false);
-  const [showAuth, setShowAuth] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
   const isAuthenticated = useAuthStore((state) => Boolean(state.accessToken));
   const logout = useLogoutMutation();
+  const openMembership = useUIStore((state) => state.openMembership);
+  const openAuth = useUIStore((state) => state.openAuth);
+
+  const handleInquiryTab = () => {
+    const params = new URLSearchParams(searchParams);
+    params.set("tab", "inquiry");
+    router.push(`?${params.toString()}`, { scroll: false });
+  };
+
+  const handleLogout = () =>
+    logout.mutate(undefined, {
+      onSettled: () => router.replace("/"),
+    });
+
   return (
     <header className="sticky top-0 z-50 bg-black text-white py-4 px-6">
       <div className="max-w-7xl mx-auto flex flex-col lg:flex-row justify-between items-center space-y-4 lg:space-y-0">
@@ -21,35 +35,27 @@ export const Header = () => {
           <button
             type="button"
             aria-label="홈으로 이동"
-            onClick={() => {
-              router.push("/");
-            }}
+            onClick={() => router.push("/")}
           >
-            <img src={mainLogo.src} alt="나인위닛 로고" />
+            <img src={mainLogo.src} alt={`${COMPANY_INFO.name} 로고`} />
           </button>
         </div>
         <nav className="flex flex-col lg:flex-row space-y-2 lg:space-y-0 lg:space-x-6 items-center">
           <button
             className="hover:text-gray-300 transition-colors"
-            onClick={() => {
-              router.push("intro");
-            }}
+            onClick={() => router.push("/intro")}
           >
             서비스 소개
           </button>
           <button
-            onClick={() => setShowMembership(true)}
+            onClick={openMembership}
             className="hover:text-gray-300 transition-colors"
           >
             PRO가입
           </button>
           {isAuthenticated ? (
             <button
-              onClick={() =>
-                logout.mutate(undefined, {
-                  onSettled: () => router.replace("/"),
-                })
-              }
+              onClick={handleLogout}
               className="hover:text-gray-300 transition-colors"
               disabled={logout.isPending}
             >
@@ -57,36 +63,28 @@ export const Header = () => {
             </button>
           ) : (
             <button
-              onClick={() => setShowAuth(true)}
+              onClick={openAuth}
               className="hover:text-gray-300 transition-colors"
             >
               로그인
             </button>
           )}
           <button
-            onClick={() => {
-              router.push("mypage", { scroll: false });
-            }}
+            onClick={() => router.push("/mypage", { scroll: false })}
+            className="hover:text-gray-300 transition-colors"
           >
             마이페이지
           </button>
           <button
-            onClick={() => {
-              const params = new URLSearchParams(searchParams);
-              params.set("tab", "inquiry");
-              router.push(`?${params.toString()}`, { scroll: false });
-            }}
+            onClick={handleInquiryTab}
             className="bg-white text-black px-4 py-2 rounded hover:bg-gray-100 transition-colors"
           >
             무료 대행 신청하기
           </button>
         </nav>
       </div>
-      <ProModal
-        showMembership={showMembership}
-        setShowMembership={setShowMembership}
-      />
-      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
+      <ProModal />
+      <AuthModal />
     </header>
   );
 };

--- a/components/main.tsx
+++ b/components/main.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { Tabs } from "@/components/ui/tabs";
 import { ProModal } from "@/components/modal/pro-modal";
 import { TabNav } from "@/components/tab/tab-nav";
@@ -21,9 +22,7 @@ export const Main = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // 구글 시트 연동 로직 (실제 구현 시 Google Apps Script 사용)
-    console.log("Form submitted:", formData);
-    alert("문의가 접수되었습니다. 빠른 시일 내에 연락드리겠습니다.");
+    toast.success("문의가 접수되었습니다. 빠른 시일 내에 연락드리겠습니다.");
     setFormData({ company: "", name: "", phone: "", email: "", inquiry: "" });
   };
 

--- a/components/main.tsx
+++ b/components/main.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -23,7 +22,6 @@ const INQUIRY_DEFAULTS: InquiryFormValues = {
 };
 
 export const Main = () => {
-  const [showMembership, setShowMembership] = useState(false);
   const searchParams = useSearchParams();
   const activeTab = searchParams.get("tab") || "seo-analysis";
 
@@ -43,13 +41,10 @@ export const Main = () => {
       <Tabs value={activeTab} className="w-full">
         <HeroSection />
         <TabNav />
-        <ServiceSection setShowMembership={setShowMembership} />
+        <ServiceSection />
         <InquirySection form={inquiryForm} onSubmit={onInquirySubmit} />
       </Tabs>
-      <ProModal
-        showMembership={showMembership}
-        setShowMembership={setShowMembership}
-      />
+      <ProModal />
     </main>
   );
 };

--- a/components/main.tsx
+++ b/components/main.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { Tabs } from "@/components/ui/tabs";
 import { ProModal } from "@/components/modal/pro-modal";
@@ -7,32 +9,33 @@ import { TabNav } from "@/components/tab/tab-nav";
 import HeroSection from "./main/hero-section";
 import { ServiceSection } from "./main/service-section";
 import { InquirySection } from "./main/inquiry-section";
+import {
+  inquirySchema,
+  type InquiryFormValues,
+} from "@/schemas/inquiry-schema";
+
+const INQUIRY_DEFAULTS: InquiryFormValues = {
+  company: "",
+  name: "",
+  phone: "",
+  email: "",
+  inquiry: "",
+};
 
 export const Main = () => {
   const [showMembership, setShowMembership] = useState(false);
   const searchParams = useSearchParams();
   const activeTab = searchParams.get("tab") || "seo-analysis";
-  const [formData, setFormData] = useState({
-    company: "",
-    name: "",
-    phone: "",
-    email: "",
-    inquiry: "",
+
+  const inquiryForm = useForm<InquiryFormValues>({
+    resolver: zodResolver(inquirySchema),
+    defaultValues: INQUIRY_DEFAULTS,
   });
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const onInquirySubmit = () => {
+    // TODO(#9): 백엔드 문의 접수 엔드포인트 확정 후 실제 호출 연결
     toast.success("문의가 접수되었습니다. 빠른 시일 내에 연락드리겠습니다.");
-    setFormData({ company: "", name: "", phone: "", email: "", inquiry: "" });
-  };
-
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+    inquiryForm.reset(INQUIRY_DEFAULTS);
   };
 
   return (
@@ -41,11 +44,7 @@ export const Main = () => {
         <HeroSection />
         <TabNav />
         <ServiceSection setShowMembership={setShowMembership} />
-        <InquirySection
-          formData={formData}
-          handleInputChange={handleInputChange}
-          handleSubmit={handleSubmit}
-        />
+        <InquirySection form={inquiryForm} onSubmit={onInquirySubmit} />
       </Tabs>
       <ProModal
         showMembership={showMembership}

--- a/components/main/hero-section.tsx
+++ b/components/main/hero-section.tsx
@@ -44,20 +44,20 @@ export default function HeroSection() {
           <div className="space-y-3 mb-10">
             <div className="group">
               <blockquote className=" hover:-rotate-1 transition-transform duration-300 text-base md:text-base text-black font-medium bg-gray-50 px-4 py-2 rounded-lg shadow-sm hover:shadow-md hover:bg-gray-100 transition-all duration-300 italic">
-                "광고 매출/효율 Maximum으로 올리는 방법은?"
+                &ldquo;광고 매출/효율 Maximum으로 올리는 방법은?&rdquo;
               </blockquote>
             </div>
 
             <div className="group">
               <blockquote className="hover:-rotate-1 transition-transform duration-300 text-base md:text-base text-black font-medium bg-gray-50 px-4 py-3 rounded-lg shadow-sm hover:shadow-md hover:bg-gray-100 transition-all duration-300 italic">
-                "상품 5개만 넘어가도 무엇을 어떻게 집중해야할지 모르는 대행사들,
-                어떻게 관리해야할까?"
+                &ldquo;상품 5개만 넘어가도 무엇을 어떻게 집중해야할지 모르는 대행사들,
+                어떻게 관리해야할까?&rdquo;
               </blockquote>
             </div>
 
             <div className="group">
               <blockquote className="hover:-rotate-1 transition-transform duration-300 text-base md:text-base text-black font-medium bg-gray-50 px-4 py-3 rounded-lg shadow-sm hover:shadow-md hover:bg-gray-100 transition-all duration-300 italic">
-                "네이버/구글/메타 등 매체별 놓치고 있는 키워드는 없나?"
+                &ldquo;네이버/구글/메타 등 매체별 놓치고 있는 키워드는 없나?&rdquo;
               </blockquote>
             </div>
           </div>

--- a/components/main/inquiry-section.tsx
+++ b/components/main/inquiry-section.tsx
@@ -46,10 +46,11 @@ export const InquirySection = ({
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-2">
+                <label htmlFor="inquiry-company" className="block text-sm font-medium mb-2">
                   업체명
                 </label>
                 <Input
+                  id="inquiry-company"
                   name="company"
                   value={formData.company}
                   onChange={handleInputChange}
@@ -58,10 +59,11 @@ export const InquirySection = ({
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2">
+                <label htmlFor="inquiry-name" className="block text-sm font-medium mb-2">
                   담당자명
                 </label>
                 <Input
+                  id="inquiry-name"
                   name="name"
                   value={formData.name}
                   onChange={handleInputChange}
@@ -72,10 +74,11 @@ export const InquirySection = ({
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-2">
+                <label htmlFor="inquiry-phone" className="block text-sm font-medium mb-2">
                   전화번호
                 </label>
                 <Input
+                  id="inquiry-phone"
                   name="phone"
                   value={formData.phone}
                   onChange={handleInputChange}
@@ -84,10 +87,11 @@ export const InquirySection = ({
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2">
+                <label htmlFor="inquiry-email" className="block text-sm font-medium mb-2">
                   이메일
                 </label>
                 <Input
+                  id="inquiry-email"
                   name="email"
                   type="email"
                   value={formData.email}
@@ -98,10 +102,11 @@ export const InquirySection = ({
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="inquiry-content" className="block text-sm font-medium mb-2">
                 문의내용
               </label>
               <Textarea
+                id="inquiry-content"
                 name="inquiry"
                 value={formData.inquiry}
                 onChange={handleInputChange}

--- a/components/main/inquiry-section.tsx
+++ b/components/main/inquiry-section.tsx
@@ -1,3 +1,4 @@
+import type { UseFormReturn } from "react-hook-form";
 import {
   Card,
   CardContent,
@@ -10,26 +11,41 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { MessageSquare, Play } from "lucide-react";
+import type { InquiryFormValues } from "@/schemas/inquiry-schema";
 
-interface InquirySectionProps {
-  formData: {
-    company: string;
-    name: string;
-    phone: string;
-    email: string;
-    inquiry: string;
-  };
-  handleInputChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void;
-  handleSubmit: (e: React.FormEvent) => void;
-}
+type InquirySectionProps = {
+  form: UseFormReturn<InquiryFormValues>;
+  onSubmit: (values: InquiryFormValues) => void;
+};
 
-export const InquirySection = ({
-  formData,
-  handleInputChange,
-  handleSubmit,
-}: InquirySectionProps) => {
+type FieldName = keyof InquiryFormValues;
+
+type FieldConfig = {
+  name: FieldName;
+  id: string;
+  label: string;
+  placeholder: string;
+  type?: string;
+};
+
+const TEXT_FIELDS: ReadonlyArray<readonly FieldConfig[]> = [
+  [
+    { name: "company", id: "inquiry-company", label: "업체명", placeholder: "업체명을 입력하세요" },
+    { name: "name", id: "inquiry-name", label: "담당자명", placeholder: "담당자명을 입력하세요" },
+  ],
+  [
+    { name: "phone", id: "inquiry-phone", label: "전화번호", placeholder: "010-0000-0000" },
+    { name: "email", id: "inquiry-email", label: "이메일", placeholder: "example@email.com", type: "email" },
+  ],
+];
+
+export const InquirySection = ({ form, onSubmit }: InquirySectionProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = form;
+
   return (
     <TabsContent value="inquiry">
       <Card>
@@ -43,81 +59,56 @@ export const InquirySection = ({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="inquiry-company" className="block text-sm font-medium mb-2">
-                  업체명
-                </label>
-                <Input
-                  id="inquiry-company"
-                  name="company"
-                  value={formData.company}
-                  onChange={handleInputChange}
-                  placeholder="업체명을 입력하세요"
-                  required
-                />
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {TEXT_FIELDS.map((row, idx) => (
+              <div key={idx} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {row.map((field) => (
+                  <div key={field.id}>
+                    <label
+                      htmlFor={field.id}
+                      className="block text-sm font-medium mb-2"
+                    >
+                      {field.label}
+                    </label>
+                    <Input
+                      id={field.id}
+                      type={field.type ?? "text"}
+                      placeholder={field.placeholder}
+                      aria-invalid={Boolean(errors[field.name])}
+                      {...register(field.name)}
+                    />
+                    {errors[field.name] && (
+                      <p className="mt-1 text-sm text-red-500">
+                        {errors[field.name]?.message}
+                      </p>
+                    )}
+                  </div>
+                ))}
               </div>
-              <div>
-                <label htmlFor="inquiry-name" className="block text-sm font-medium mb-2">
-                  담당자명
-                </label>
-                <Input
-                  id="inquiry-name"
-                  name="name"
-                  value={formData.name}
-                  onChange={handleInputChange}
-                  placeholder="담당자명을 입력하세요"
-                  required
-                />
-              </div>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="inquiry-phone" className="block text-sm font-medium mb-2">
-                  전화번호
-                </label>
-                <Input
-                  id="inquiry-phone"
-                  name="phone"
-                  value={formData.phone}
-                  onChange={handleInputChange}
-                  placeholder="010-0000-0000"
-                  required
-                />
-              </div>
-              <div>
-                <label htmlFor="inquiry-email" className="block text-sm font-medium mb-2">
-                  이메일
-                </label>
-                <Input
-                  id="inquiry-email"
-                  name="email"
-                  type="email"
-                  value={formData.email}
-                  onChange={handleInputChange}
-                  placeholder="example@email.com"
-                  required
-                />
-              </div>
-            </div>
+            ))}
             <div>
-              <label htmlFor="inquiry-content" className="block text-sm font-medium mb-2">
+              <label
+                htmlFor="inquiry-content"
+                className="block text-sm font-medium mb-2"
+              >
                 문의내용
               </label>
               <Textarea
                 id="inquiry-content"
-                name="inquiry"
-                value={formData.inquiry}
-                onChange={handleInputChange}
                 placeholder="문의하실 내용을 자세히 입력해주세요"
                 rows={5}
-                required
+                aria-invalid={Boolean(errors.inquiry)}
+                {...register("inquiry")}
               />
+              {errors.inquiry && (
+                <p className="mt-1 text-sm text-red-500">
+                  {errors.inquiry.message}
+                </p>
+              )}
             </div>
-            <Button type="submit" className="w-full">
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
               <Play className="w-4 h-4 mr-2" />
-              문의하기
+              {isSubmitting ? "전송 중..." : "문의하기"}
             </Button>
           </form>
         </CardContent>

--- a/components/main/service-section.tsx
+++ b/components/main/service-section.tsx
@@ -6,17 +6,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { TabsContent } from "@/components/ui/tabs";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Search, Star, Download } from "lucide-react";
 import { services } from "@/data/service-data";
+import { SeoAnalysisPanel } from "./service-section/seo-analysis-panel";
+import { ServiceCtaPanel } from "./service-section/service-cta-panel";
 
-interface ServiceSectionProps {
-  setShowMembership: (show: boolean) => void;
-}
+const SEO_SERVICE_ID = "seo-analysis";
 
-export const ServiceSection = ({ setShowMembership }: ServiceSectionProps) => {
+export const ServiceSection = () => {
   return (
     <>
       {services.map((service) => (
@@ -27,88 +23,18 @@ export const ServiceSection = ({ setShowMembership }: ServiceSectionProps) => {
                 {service.icon}
                 <span>{service.title}</span>
               </CardTitle>
-
               <CardDescription>{service.description}</CardDescription>
             </CardHeader>
             <CardContent>
-              {service.id === "seo-analysis" && (
-                <div className="space-y-4">
-                  <div className="flex space-x-2">
-                    <Input
-                      placeholder="스마트스토어 URL을 입력하세요"
-                      className="flex-1"
-                    />
-                    <Input placeholder="키워드 입력" className="w-48" />
-                    <Button>
-                      <Search className="w-4 h-4 mr-2" />
-                      분석 시작
-                    </Button>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-                    <Card>
-                      <CardContent className="p-4">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm text-gray-600">
-                            현재 순위
-                          </span>
-                          <Badge variant="secondary">3위</Badge>
-                        </div>
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardContent className="p-4">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm text-gray-600">
-                            예상 매출
-                          </span>
-                          <span className="font-bold">₩2,450,000</span>
-                        </div>
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardContent className="p-4">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm text-gray-600">
-                            SEO 점수
-                          </span>
-                          <div className="flex items-center">
-                            <Star className="w-4 h-4 text-yellow-500 mr-1" />
-                            <span className="font-bold">8.5/10</span>
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  </div>
-                  <Button className="w-full mt-4">
-                    <Download className="w-4 h-4 mr-2" />
-                    상세 분석 보고서 다운로드
-                  </Button>
-                </div>
-              )}
-              {service.id !== "seo-analysis" && (
-                <div className="text-center py-12">
-                  <div className="mb-4">{service.icon}</div>
-                  <h3 className="text-lg font-semibold mb-2">
-                    {service.title}
-                  </h3>
-                  <p className="text-gray-600 mb-4 ">{service.description}</p>
-                  <p className="text-base font-medium text-gray-600 ">
-                    {service.text?.[0]?.content}
-                  </p>
-
-                  <p className="text-base font-medium text-gray-600 ">
-                    {service.text?.[1]?.content}
-                  </p>
-
-                  <p className="text-base font-medium text-gray-600 ">
-                    {service.text?.[2]?.content}
-                  </p>
-                  <br />
-
-                  <Button onClick={() => setShowMembership(true)}>
-                    PRO 기능 이용하기
-                  </Button>
-                </div>
+              {service.id === SEO_SERVICE_ID ? (
+                <SeoAnalysisPanel />
+              ) : (
+                <ServiceCtaPanel
+                  icon={service.icon}
+                  title={service.title}
+                  description={service.description}
+                  lines={service.text}
+                />
               )}
             </CardContent>
           </Card>

--- a/components/main/service-section.tsx
+++ b/components/main/service-section.tsx
@@ -11,12 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, Star, Download } from "lucide-react";
 import { services } from "@/data/service-data";
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from "@/components/ui/tooltip";
+
 interface ServiceSectionProps {
   setShowMembership: (show: boolean) => void;
 }

--- a/components/main/service-section/seo-analysis-panel.tsx
+++ b/components/main/service-section/seo-analysis-panel.tsx
@@ -1,0 +1,61 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Search, Star, Download } from "lucide-react";
+
+export const SeoAnalysisPanel = () => {
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <Input
+          placeholder="스마트스토어 URL을 입력하세요"
+          className="flex-1"
+          aria-label="스마트스토어 URL"
+        />
+        <Input
+          placeholder="키워드 입력"
+          className="w-48"
+          aria-label="분석 키워드"
+        />
+        <Button>
+          <Search className="w-4 h-4 mr-2" />
+          분석 시작
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-600">현재 순위</span>
+              <Badge variant="secondary">3위</Badge>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-600">예상 매출</span>
+              <span className="font-bold">₩2,450,000</span>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-600">SEO 점수</span>
+              <div className="flex items-center">
+                <Star className="w-4 h-4 text-yellow-500 mr-1" />
+                <span className="font-bold">8.5/10</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      <Button className="w-full mt-4">
+        <Download className="w-4 h-4 mr-2" />
+        상세 분석 보고서 다운로드
+      </Button>
+    </div>
+  );
+};

--- a/components/main/service-section/service-cta-panel.tsx
+++ b/components/main/service-section/service-cta-panel.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { useUIStore } from "@/stores/ui-store";
+
+type ServiceCtaPanelProps = {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  lines?: Array<{ content: string }>;
+};
+
+export const ServiceCtaPanel = ({
+  icon,
+  title,
+  description,
+  lines = [],
+}: ServiceCtaPanelProps) => {
+  const openMembership = useUIStore((state) => state.openMembership);
+
+  return (
+    <div className="text-center py-12">
+      <div className="mb-4">{icon}</div>
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      <p className="text-gray-600 mb-4">{description}</p>
+      {lines.slice(0, 3).map((line, idx) => (
+        <p key={idx} className="text-base font-medium text-gray-600">
+          {line.content}
+        </p>
+      ))}
+      <br />
+      <Button onClick={openMembership}>PRO 기능 이용하기</Button>
+    </div>
+  );
+};

--- a/components/modal/auth-modal.tsx
+++ b/components/modal/auth-modal.tsx
@@ -3,13 +3,11 @@
 import { useState } from "react";
 import { LoginModal } from "./login-modal";
 import { SignUpModal } from "./signup-modal";
+import { useUIStore } from "@/stores/ui-store";
 
-interface AuthModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export function AuthModal({ isOpen, onClose }: AuthModalProps) {
+export function AuthModal() {
+  const isOpen = useUIStore((state) => state.isAuthOpen);
+  const close = useUIStore((state) => state.closeAuth);
   const [isLogin, setIsLogin] = useState(true);
 
   const toggleModal = () => {
@@ -19,26 +17,20 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   if (!isOpen) return null;
 
   return (
-    <>
-      <div
-        className={`transition-opacity duration-300 ${
-          isOpen ? "opacity-100" : "opacity-0"
-        }`}
-      >
-        {isLogin ? (
-          <LoginModal
-            isOpen={isOpen}
-            onClose={onClose}
-            onSignUpClick={toggleModal}
-          />
-        ) : (
-          <SignUpModal
-            isOpen={isOpen}
-            onClose={onClose}
-            onLoginClick={toggleModal}
-          />
-        )}
-      </div>
-    </>
+    <div className="transition-opacity duration-300 opacity-100">
+      {isLogin ? (
+        <LoginModal
+          isOpen={isOpen}
+          onClose={close}
+          onSignUpClick={toggleModal}
+        />
+      ) : (
+        <SignUpModal
+          isOpen={isOpen}
+          onClose={close}
+          onLoginClick={toggleModal}
+        />
+      )}
+    </div>
   );
 }

--- a/components/modal/login-modal.tsx
+++ b/components/modal/login-modal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,6 +13,9 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { loginSchema, type LoginFormValues } from "@/schemas/auth-schemas";
+import { useLoginMutation } from "@/hooks/use-auth";
+import { GoogleLoginButton } from "@/components/auth/google-login-button";
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -23,8 +28,35 @@ export function LoginModal({
   onClose,
   onSignUpClick,
 }: LoginModalProps) {
+  const loginMutation = useLoginMutation();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { eml_adr: "", password: "" },
+  });
+
+  const onSubmit = (values: LoginFormValues) => {
+    loginMutation.mutate(values, {
+      onSuccess: () => {
+        reset();
+        onClose();
+      },
+    });
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      reset();
+      onClose();
+    }
+  };
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>로그인</DialogTitle>
@@ -32,39 +64,53 @@ export function LoginModal({
             로그인하여 모든 기능을 이용해보세요.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="id" className="text-right">
-              아이디
-            </Label>
+        <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="eml_adr">이메일</Label>
             <Input
-              id="id"
-              placeholder="아이디를 입력하세요"
-              className="col-span-3"
+              id="eml_adr"
+              type="email"
+              autoComplete="email"
+              placeholder="이메일을 입력하세요"
+              {...register("eml_adr")}
             />
+            {errors.eml_adr && (
+              <p className="text-sm text-red-500">{errors.eml_adr.message}</p>
+            )}
           </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="password" className="text-right">
-              비밀번호
-            </Label>
+          <div className="grid gap-2">
+            <Label htmlFor="password">비밀번호</Label>
             <Input
               id="password"
               type="password"
+              autoComplete="current-password"
               placeholder="비밀번호를 입력하세요"
-              className="col-span-3"
+              {...register("password")}
             />
+            {errors.password && (
+              <p className="text-sm text-red-500">{errors.password.message}</p>
+            )}
           </div>
-        </div>
 
-        <DialogFooter>
-          <Button variant="outline" className="w-full">
-            Google 로그인
-          </Button>
-          <Button type="submit">로그인</Button>
-          <Button type="button" variant="secondary" onClick={onSignUpClick}>
-            회원가입
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-col">
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={loginMutation.isPending}
+            >
+              {loginMutation.isPending ? "로그인 중..." : "로그인"}
+            </Button>
+            <GoogleLoginButton onSuccess={onClose} />
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full"
+              onClick={onSignUpClick}
+            >
+              회원가입
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/components/modal/pro-modal.tsx
+++ b/components/modal/pro-modal.tsx
@@ -7,6 +7,8 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { MEMBERSHIP_PLANS } from "@/config/pricing";
+
 export const ProModal = ({
   showMembership,
   setShowMembership,
@@ -14,12 +16,6 @@ export const ProModal = ({
   showMembership: boolean;
   setShowMembership: (show: boolean) => void;
 }) => {
-  const membershipPlans = [
-    { period: "1개월", price: 7900, popular: false },
-    { period: "3개월", price: 19800, popular: true },
-    { period: "1년", price: 80000, popular: false },
-  ];
-
   if (!showMembership) return null;
 
   return (
@@ -33,7 +29,7 @@ export const ProModal = ({
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-            {membershipPlans.map((plan) => (
+            {MEMBERSHIP_PLANS.map((plan) => (
               <Card
                 key={plan.period}
                 className={`relative ${

--- a/components/modal/pro-modal.tsx
+++ b/components/modal/pro-modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Card,
   CardContent,
@@ -8,15 +10,13 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MEMBERSHIP_PLANS } from "@/config/pricing";
+import { useUIStore } from "@/stores/ui-store";
 
-export const ProModal = ({
-  showMembership,
-  setShowMembership,
-}: {
-  showMembership: boolean;
-  setShowMembership: (show: boolean) => void;
-}) => {
-  if (!showMembership) return null;
+export const ProModal = () => {
+  const isOpen = useUIStore((state) => state.isMembershipOpen);
+  const close = useUIStore((state) => state.closeMembership);
+
+  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -52,7 +52,7 @@ export const ProModal = ({
             ))}
           </div>
           <div className="flex justify-end space-x-2">
-            <Button variant="outline" onClick={() => setShowMembership(false)}>
+            <Button variant="outline" onClick={close}>
               취소
             </Button>
           </div>

--- a/components/modal/signup-modal.tsx
+++ b/components/modal/signup-modal.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,7 +15,20 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowLeft } from "lucide-react";
+import {
+  signupEmailSchema,
+  type SignupEmailValues,
+  verifyCodeSchema,
+  type VerifyCodeValues,
+  signupDetailsSchema,
+  type SignupDetailsValues,
+} from "@/schemas/auth-schemas";
+import {
+  useSendCodeMutation,
+  useVerifyCodeMutation,
+  useSignupMutation,
+} from "@/hooks/use-auth";
+import { GoogleLoginButton } from "@/components/auth/google-login-button";
 
 interface SignUpModalProps {
   isOpen: boolean;
@@ -19,74 +36,270 @@ interface SignUpModalProps {
   onLoginClick: () => void;
 }
 
+type Step = "email" | "code" | "details";
+
 export function SignUpModal({
   isOpen,
   onClose,
   onLoginClick,
 }: SignUpModalProps) {
+  const [step, setStep] = useState<Step>("email");
+  const [email, setEmail] = useState("");
+
+  const sendCode = useSendCodeMutation();
+  const verifyCode = useVerifyCodeMutation();
+  const signup = useSignupMutation();
+
+  const emailForm = useForm<SignupEmailValues>({
+    resolver: zodResolver(signupEmailSchema),
+    defaultValues: { eml_adr: "" },
+  });
+
+  const codeForm = useForm<VerifyCodeValues>({
+    resolver: zodResolver(verifyCodeSchema),
+    defaultValues: { code: "" },
+  });
+
+  const detailsForm = useForm<SignupDetailsValues>({
+    resolver: zodResolver(signupDetailsSchema),
+    defaultValues: { nm: "", phn_no: "", password: "", confirmPassword: "" },
+  });
+
+  const resetAll = () => {
+    setStep("email");
+    setEmail("");
+    emailForm.reset();
+    codeForm.reset();
+    detailsForm.reset();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      resetAll();
+      onClose();
+    }
+  };
+
+  const onEmailSubmit = ({ eml_adr }: SignupEmailValues) => {
+    sendCode.mutate(eml_adr, {
+      onSuccess: () => {
+        setEmail(eml_adr);
+        setStep("code");
+      },
+    });
+  };
+
+  const onCodeSubmit = ({ code }: VerifyCodeValues) => {
+    verifyCode.mutate(
+      { eml_adr: email, code },
+      {
+        onSuccess: () => setStep("details"),
+      },
+    );
+  };
+
+  const onDetailsSubmit = (values: SignupDetailsValues) => {
+    signup.mutate(
+      {
+        eml_adr: email,
+        password: values.password,
+        nm: values.nm,
+        phn_no: values.phn_no || undefined,
+      },
+      {
+        onSuccess: () => {
+          resetAll();
+          onClose();
+        },
+      },
+    );
+  };
+
+  const goBack = () => {
+    if (step === "details") setStep("code");
+    else if (step === "code") setStep("email");
+    else onLoginClick();
+  };
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <div className="absolute top-4 left-4">
           <Button
             variant="ghost"
             size="icon"
-            onClick={onLoginClick}
-            className="bg-gray-400 hover:bg-[#333]"
+            onClick={goBack}
+            aria-label="이전 단계로"
+            className="bg-gray-400 hover:bg-gray-700"
           >
             <ArrowLeft className="h-4 w-4 text-white" />
           </Button>
         </div>
         <DialogHeader className="pt-10">
-          <DialogTitle className=" text-center">회원가입</DialogTitle>
-          <DialogDescription className=" text-center">
-            새로운 계정을 생성합니다.
+          <DialogTitle className="text-center">회원가입</DialogTitle>
+          <DialogDescription className="text-center">
+            {step === "email" && "가입할 이메일을 입력하세요."}
+            {step === "code" && `${email}로 보낸 인증 코드를 입력하세요.`}
+            {step === "details" && "추가 정보를 입력하면 가입이 완료됩니다."}
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="id" className="text-right">
-              아이디
-            </Label>
-            <Input
-              id="id"
-              placeholder="아이디를 입력하세요"
-              className="col-span-3"
-            />
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="password" className="text-right">
-              비밀번호
-            </Label>
-            <Input
-              id="password"
-              type="password"
-              placeholder="비밀번호를 입력하세요"
-              className="col-span-3"
-            />
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="confirm-password" className="text-right">
-              비밀번호 확인
-            </Label>
-            <Input
-              id="confirm-password"
-              type="password"
-              placeholder="비밀번호를 다시 입력하세요"
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div className="mt-4">
-          <Button variant="outline" className="w-full">
-            Google로 시작하기
-          </Button>
-        </div>
-        <DialogFooter>
-          <Button type="submit" className="w-full">
-            회원가입 완료
-          </Button>
-        </DialogFooter>
+
+        {step === "email" && (
+          <form
+            onSubmit={emailForm.handleSubmit(onEmailSubmit)}
+            className="grid gap-4 py-4"
+          >
+            <div className="grid gap-2">
+              <Label htmlFor="signup-email">이메일</Label>
+              <Input
+                id="signup-email"
+                type="email"
+                autoComplete="email"
+                placeholder="이메일을 입력하세요"
+                {...emailForm.register("eml_adr")}
+              />
+              {emailForm.formState.errors.eml_adr && (
+                <p className="text-sm text-red-500">
+                  {emailForm.formState.errors.eml_adr.message}
+                </p>
+              )}
+            </div>
+            <div className="mt-2">
+              <GoogleLoginButton
+                label="Google로 시작하기"
+                onSuccess={() => {
+                  resetAll();
+                  onClose();
+                }}
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={sendCode.isPending}
+              >
+                {sendCode.isPending ? "코드 발송 중..." : "인증 코드 받기"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+
+        {step === "code" && (
+          <form
+            onSubmit={codeForm.handleSubmit(onCodeSubmit)}
+            className="grid gap-4 py-4"
+          >
+            <div className="grid gap-2">
+              <Label htmlFor="verify-code">인증 코드</Label>
+              <Input
+                id="verify-code"
+                inputMode="numeric"
+                placeholder="이메일로 받은 코드를 입력하세요"
+                {...codeForm.register("code")}
+              />
+              {codeForm.formState.errors.code && (
+                <p className="text-sm text-red-500">
+                  {codeForm.formState.errors.code.message}
+                </p>
+              )}
+            </div>
+            <div>
+              <Button
+                type="button"
+                variant="link"
+                className="px-0 text-xs"
+                onClick={() => sendCode.mutate(email)}
+                disabled={sendCode.isPending}
+              >
+                코드 재발송
+              </Button>
+            </div>
+            <DialogFooter>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={verifyCode.isPending}
+              >
+                {verifyCode.isPending ? "확인 중..." : "다음"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+
+        {step === "details" && (
+          <form
+            onSubmit={detailsForm.handleSubmit(onDetailsSubmit)}
+            className="grid gap-4 py-4"
+          >
+            <div className="grid gap-2">
+              <Label htmlFor="signup-name">이름</Label>
+              <Input
+                id="signup-name"
+                placeholder="이름을 입력하세요"
+                {...detailsForm.register("nm")}
+              />
+              {detailsForm.formState.errors.nm && (
+                <p className="text-sm text-red-500">
+                  {detailsForm.formState.errors.nm.message}
+                </p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="signup-phone">전화번호 (선택)</Label>
+              <Input
+                id="signup-phone"
+                inputMode="tel"
+                placeholder="010-1234-5678"
+                {...detailsForm.register("phn_no")}
+              />
+              {detailsForm.formState.errors.phn_no && (
+                <p className="text-sm text-red-500">
+                  {detailsForm.formState.errors.phn_no.message}
+                </p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="signup-password">비밀번호</Label>
+              <Input
+                id="signup-password"
+                type="password"
+                autoComplete="new-password"
+                placeholder="8자 이상"
+                {...detailsForm.register("password")}
+              />
+              {detailsForm.formState.errors.password && (
+                <p className="text-sm text-red-500">
+                  {detailsForm.formState.errors.password.message}
+                </p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="signup-confirm">비밀번호 확인</Label>
+              <Input
+                id="signup-confirm"
+                type="password"
+                autoComplete="new-password"
+                placeholder="비밀번호를 다시 입력하세요"
+                {...detailsForm.register("confirmPassword")}
+              />
+              {detailsForm.formState.errors.confirmPassword && (
+                <p className="text-sm text-red-500">
+                  {detailsForm.formState.errors.confirmPassword.message}
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={signup.isPending}
+              >
+                {signup.isPending ? "가입 중..." : "회원가입 완료"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/components/mypage/mypage-menu.tsx
+++ b/components/mypage/mypage-menu.tsx
@@ -1,8 +1,20 @@
+"use client";
 
+import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useLogoutMutation } from "@/hooks/use-auth";
 
 export default function MypageMenu() {
+  const router = useRouter();
+  const logout = useLogoutMutation();
+
+  const handleLogout = () => {
+    logout.mutate(undefined, {
+      onSettled: () => router.replace("/"),
+    });
+  };
+
   return (
     <Card className="w-full">
       <CardContent className="flex flex-col gap-2 p-4">
@@ -10,7 +22,14 @@ export default function MypageMenu() {
         <Button variant="ghost" className="justify-start">Order History</Button>
         <Button variant="ghost" className="justify-start">Shipping Addresses</Button>
         <Button variant="ghost" className="justify-start">Payment Methods</Button>
-        <Button variant="ghost" className="justify-start text-red-500">Logout</Button>
+        <Button
+          variant="ghost"
+          className="justify-start text-red-500"
+          onClick={handleLogout}
+          disabled={logout.isPending}
+        >
+          {logout.isPending ? "로그아웃 중..." : "Logout"}
+        </Button>
       </CardContent>
     </Card>
   );

--- a/components/mypage/user-profile.tsx
+++ b/components/mypage/user-profile.tsx
@@ -1,9 +1,17 @@
+"use client";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAuthStore } from "@/stores/auth-store";
 
 export default function UserProfile() {
+  const user = useAuthStore((state) => state.user);
+
+  const displayName = user?.nm?.trim() || user?.eml_adr || "사용자";
+  const displayEmail = user?.eml_adr ?? "";
+  const initial = (user?.nm?.[0] ?? user?.eml_adr?.[0] ?? "U").toUpperCase();
+
   return (
     <Card className="w-full">
       <CardHeader>
@@ -11,12 +19,14 @@ export default function UserProfile() {
       </CardHeader>
       <CardContent className="flex items-center gap-4">
         <Avatar className="h-16 w-16">
-          <AvatarImage src="/placeholder-user.jpg" alt="User avatar" />
-          <AvatarFallback>U</AvatarFallback>
+          <AvatarImage src="/placeholder-user.jpg" alt="사용자 프로필 사진" />
+          <AvatarFallback>{initial}</AvatarFallback>
         </Avatar>
         <div className="flex flex-col">
-          <p className="text-lg font-semibold">Username</p>
-          <p className="text-sm text-muted-foreground">user@example.com</p>
+          <p className="text-lg font-semibold">{displayName}</p>
+          {displayEmail && (
+            <p className="text-sm text-muted-foreground">{displayEmail}</p>
+          )}
         </div>
         <Button className="ml-auto">Edit Profile</Button>
       </CardContent>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -54,8 +54,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -69,7 +69,7 @@ ChartContainer.displayName = "Chart"
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
+    ([, config]) => config.theme || config.color
   )
 
   if (!colorConfig.length) {

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -18,13 +18,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
-
 let count = 0
 
 function genId() {
@@ -32,7 +25,12 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST"
+  UPDATE_TOAST: "UPDATE_TOAST"
+  DISMISS_TOAST: "DISMISS_TOAST"
+  REMOVE_TOAST: "REMOVE_TOAST"
+}
 
 type Action =
   | {

--- a/config/company.ts
+++ b/config/company.ts
@@ -1,0 +1,11 @@
+export const COMPANY_INFO = {
+  name: "나인위닛",
+  tagline: "스마트스토어 SEO 최적화 전문 서비스",
+  subTagline: "서비스 데이터 분석 기반 매출 최적화 전문",
+  address: "수원시 세류동 482-7 501호",
+  phone: "010-4590-4917",
+  email: "9winit01@gmail.com",
+  businessNumber: "246-17-02470",
+  ceo: "배대근",
+  copyrightYear: 2024,
+} as const;

--- a/config/pricing.ts
+++ b/config/pricing.ts
@@ -1,0 +1,11 @@
+export type MembershipPlan = {
+  period: string;
+  price: number;
+  popular: boolean;
+};
+
+export const MEMBERSHIP_PLANS: readonly MembershipPlan[] = [
+  { period: "1개월", price: 7900, popular: false },
+  { period: "3개월", price: 19800, popular: true },
+  { period: "1년", price: 80000, popular: false },
+] as const;

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  authService,
+  extractTokens,
+  type LoginRequest,
+  type SignupRequest,
+} from "@/services/auth-service";
+import { useAuthStore } from "@/stores/auth-store";
+import { getOrCreateDeviceId } from "@/lib/auth/storage";
+import { ApiError } from "@/lib/api-client";
+
+const handleAuthSuccess = (
+  res: Awaited<ReturnType<typeof authService.login>>,
+  fallbackEmail?: string,
+): boolean => {
+  const { access, refresh } = extractTokens(res);
+  if (!access) {
+    toast.error("로그인 응답이 올바르지 않습니다. 관리자에게 문의해주세요.");
+    return false;
+  }
+  useAuthStore.getState().setSession({
+    user: res.user ?? (fallbackEmail ? { eml_adr: fallbackEmail } : null),
+    accessToken: access,
+    refreshToken: refresh ?? undefined,
+  });
+  return true;
+};
+
+const toastError = (err: unknown, fallback: string): void => {
+  const message = err instanceof ApiError ? err.message : fallback;
+  toast.error(message);
+};
+
+export const useLoginMutation = () =>
+  useMutation({
+    mutationFn: (body: LoginRequest) => authService.login(body),
+    onSuccess: (res, variables) => {
+      if (handleAuthSuccess(res, variables.eml_adr)) {
+        toast.success("로그인되었습니다.");
+      }
+    },
+    onError: (err) => toastError(err, "로그인에 실패했습니다."),
+  });
+
+export const useSendCodeMutation = () =>
+  useMutation({
+    mutationFn: (eml_adr: string) => authService.sendCode(eml_adr),
+    onSuccess: () => toast.success("인증 코드를 이메일로 보냈습니다."),
+    onError: (err) => toastError(err, "코드 발송에 실패했습니다."),
+  });
+
+export const useVerifyCodeMutation = () =>
+  useMutation({
+    mutationFn: (params: { eml_adr: string; code: string }) =>
+      authService.verifyCode(params.eml_adr, params.code),
+    onError: (err) => toastError(err, "인증 코드가 올바르지 않습니다."),
+  });
+
+export const useSignupMutation = () =>
+  useMutation({
+    mutationFn: (body: SignupRequest) => authService.signup(body),
+    onSuccess: (res, variables) => {
+      if (handleAuthSuccess(res, variables.eml_adr)) {
+        toast.success("회원가입이 완료되었습니다.");
+      }
+    },
+    onError: (err) => toastError(err, "회원가입에 실패했습니다."),
+  });
+
+export const useGoogleLoginMutation = () =>
+  useMutation({
+    mutationFn: (id_token: string) => authService.googleVerify(id_token),
+    onSuccess: (res) => {
+      if (handleAuthSuccess(res)) {
+        toast.success("Google 계정으로 로그인되었습니다.");
+      }
+    },
+    onError: (err) => toastError(err, "Google 로그인에 실패했습니다."),
+  });
+
+export const useLogoutMutation = () =>
+  useMutation({
+    mutationFn: () => authService.logout(getOrCreateDeviceId()),
+    onSettled: () => {
+      useAuthStore.getState().clearSession();
+    },
+    onSuccess: () => toast.success("로그아웃되었습니다."),
+    onError: (err) => {
+      const message =
+        err instanceof ApiError ? err.message : "로그아웃 처리 중 문제가 발생했습니다.";
+      toast.error(message);
+    },
+  });

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -18,13 +18,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
-
 let count = 0
 
 function genId() {
@@ -32,7 +25,12 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST"
+  UPDATE_TOAST: "UPDATE_TOAST"
+  DISMISS_TOAST: "DISMISS_TOAST"
+  REMOVE_TOAST: "REMOVE_TOAST"
+}
 
 type Action =
   | {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,0 +1,126 @@
+import { tokenStorage } from "@/lib/auth/storage";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.ninewinit.store";
+
+export class ApiError extends Error {
+  status: number;
+  data: unknown;
+  constructor(message: string, status: number, data: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+type RequestOptions = {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: unknown;
+  auth?: boolean;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+};
+
+let inFlightRefresh: Promise<string | null> | null = null;
+let onUnauthorizedHandler: (() => void) | null = null;
+
+export const setUnauthorizedHandler = (fn: () => void): void => {
+  onUnauthorizedHandler = fn;
+};
+
+const refreshAccessToken = async (): Promise<string | null> => {
+  if (inFlightRefresh) return inFlightRefresh;
+  const refresh = tokenStorage.getRefreshToken();
+  if (!refresh) return null;
+
+  inFlightRefresh = (async () => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/user/login/refresh/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh }),
+      });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { access_token?: string; access?: string };
+      const newAccess = data.access_token ?? data.access ?? null;
+      if (newAccess) tokenStorage.setTokens(newAccess, refresh);
+      return newAccess;
+    } catch {
+      return null;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+};
+
+const buildHeaders = (
+  options: RequestOptions,
+  accessToken: string | null,
+): HeadersInit => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers ?? {}),
+  };
+  if (options.auth && accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return headers;
+};
+
+const parseResponse = async <T>(res: Response): Promise<T> => {
+  const text = await res.text();
+  if (!text) return undefined as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text as unknown as T;
+  }
+};
+
+export const apiFetch = async <T = unknown>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> => {
+  const { method = "GET", body, auth = false, signal } = options;
+  const url = `${API_BASE_URL}${path}`;
+
+  const send = async (token: string | null): Promise<Response> =>
+    fetch(url, {
+      method,
+      headers: buildHeaders(options, token),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal,
+    });
+
+  let token = auth ? tokenStorage.getAccessToken() : null;
+  let res = await send(token);
+
+  if (res.status === 401 && auth) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed) {
+      token = refreshed;
+      res = await send(token);
+    }
+    if (res.status === 401) {
+      tokenStorage.clear();
+      onUnauthorizedHandler?.();
+      const data = await parseResponse<unknown>(res);
+      throw new ApiError("Unauthorized", 401, data);
+    }
+  }
+
+  const data = await parseResponse<T>(res);
+
+  if (!res.ok) {
+    const message =
+      (typeof data === "object" && data !== null && "detail" in data
+        ? String((data as { detail: unknown }).detail)
+        : `Request failed (${res.status})`) || `Request failed (${res.status})`;
+    throw new ApiError(message, res.status, data);
+  }
+
+  return data;
+};

--- a/lib/auth/storage.ts
+++ b/lib/auth/storage.ts
@@ -1,0 +1,42 @@
+export const STORAGE_KEYS = {
+  accessToken: "nw_access_token",
+  refreshToken: "nw_refresh_token",
+  deviceId: "nw_device_id",
+} as const;
+
+const isBrowser = (): boolean => typeof window !== "undefined";
+
+export const tokenStorage = {
+  getAccessToken: (): string | null => {
+    if (!isBrowser()) return null;
+    return window.localStorage.getItem(STORAGE_KEYS.accessToken);
+  },
+  getRefreshToken: (): string | null => {
+    if (!isBrowser()) return null;
+    return window.localStorage.getItem(STORAGE_KEYS.refreshToken);
+  },
+  setTokens: (access: string, refresh?: string): void => {
+    if (!isBrowser()) return;
+    window.localStorage.setItem(STORAGE_KEYS.accessToken, access);
+    if (refresh) {
+      window.localStorage.setItem(STORAGE_KEYS.refreshToken, refresh);
+    }
+  },
+  clear: (): void => {
+    if (!isBrowser()) return;
+    window.localStorage.removeItem(STORAGE_KEYS.accessToken);
+    window.localStorage.removeItem(STORAGE_KEYS.refreshToken);
+  },
+};
+
+export const getOrCreateDeviceId = (): string => {
+  if (!isBrowser()) return "ssr-no-device";
+  const existing = window.localStorage.getItem(STORAGE_KEYS.deviceId);
+  if (existing) return existing;
+  const fresh =
+    typeof window.crypto?.randomUUID === "function"
+      ? window.crypto.randomUUID()
+      : `web-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  window.localStorage.setItem(STORAGE_KEYS.deviceId, fresh);
+  return fresh;
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  images: {
-    unoptimized: true,
-  },
-}
+const nextConfig = {}
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
+        "@react-oauth/google": "^0.13.5",
         "@tanstack/react-query": "^5.81.5",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -57,7 +58,8 @@
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.6",
-        "zod": "^3.24.1"
+        "zod": "^3.24.1",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -2296,6 +2298,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -8035,6 +8047,35 @@
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@react-oauth/google": "^0.13.5",
     "@tanstack/react-query": "^5.81.5",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
@@ -58,7 +59,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/recoil/auth.ts
+++ b/recoil/auth.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const loginState = atom({
-  key: 'loginState',
-  default: false,
-});

--- a/schemas/auth-schemas.ts
+++ b/schemas/auth-schemas.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  eml_adr: z
+    .string({ required_error: "이메일을 입력해주세요." })
+    .min(1, "이메일을 입력해주세요.")
+    .email("올바른 이메일 형식이 아닙니다."),
+  password: z
+    .string({ required_error: "비밀번호를 입력해주세요." })
+    .min(1, "비밀번호를 입력해주세요."),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;
+
+export const signupEmailSchema = z.object({
+  eml_adr: z
+    .string()
+    .min(1, "이메일을 입력해주세요.")
+    .email("올바른 이메일 형식이 아닙니다."),
+});
+
+export type SignupEmailValues = z.infer<typeof signupEmailSchema>;
+
+export const verifyCodeSchema = z.object({
+  code: z
+    .string()
+    .min(1, "인증코드를 입력해주세요.")
+    .max(10, "인증코드가 너무 깁니다."),
+});
+
+export type VerifyCodeValues = z.infer<typeof verifyCodeSchema>;
+
+export const signupDetailsSchema = z
+  .object({
+    nm: z.string().min(1, "이름을 입력해주세요.").max(150),
+    phn_no: z
+      .string()
+      .regex(/^[0-9-]*$/, "숫자와 하이픈만 입력 가능합니다.")
+      .max(20)
+      .optional()
+      .or(z.literal("")),
+    password: z
+      .string()
+      .min(8, "비밀번호는 8자 이상이어야 합니다.")
+      .max(128, "비밀번호가 너무 깁니다."),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });
+
+export type SignupDetailsValues = z.infer<typeof signupDetailsSchema>;

--- a/schemas/inquiry-schema.ts
+++ b/schemas/inquiry-schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const inquirySchema = z.object({
+  company: z.string().min(1, "업체명을 입력해주세요.").max(100),
+  name: z.string().min(1, "담당자명을 입력해주세요.").max(50),
+  phone: z
+    .string()
+    .min(1, "전화번호를 입력해주세요.")
+    .regex(/^[0-9-+\s]+$/, "올바른 전화번호 형식이 아닙니다.")
+    .max(20),
+  email: z
+    .string()
+    .min(1, "이메일을 입력해주세요.")
+    .email("올바른 이메일 형식이 아닙니다."),
+  inquiry: z
+    .string()
+    .min(1, "문의 내용을 입력해주세요.")
+    .max(2000, "문의 내용이 너무 깁니다."),
+});
+
+export type InquiryFormValues = z.infer<typeof inquirySchema>;

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -1,0 +1,67 @@
+import { apiFetch } from "@/lib/api-client";
+
+export type AuthUser = {
+  eml_adr: string;
+  nm?: string;
+  phn_no?: string | null;
+};
+
+export type LoginResponse = {
+  access_token?: string;
+  refresh_token?: string;
+  access?: string;
+  refresh?: string;
+  user?: AuthUser;
+};
+
+export type LoginRequest = {
+  eml_adr: string;
+  password: string;
+};
+
+export type SignupRequest = {
+  eml_adr: string;
+  password: string;
+  nm: string;
+  phn_no?: string;
+};
+
+export const authService = {
+  login: (body: LoginRequest) =>
+    apiFetch<LoginResponse>("/user/auth/login/", { method: "POST", body }),
+
+  signup: (body: SignupRequest) =>
+    apiFetch<LoginResponse>("/user/auth/signup/", { method: "POST", body }),
+
+  sendCode: (eml_adr: string) =>
+    apiFetch<unknown>("/user/auth/send-code/", {
+      method: "POST",
+      body: { eml_adr },
+    }),
+
+  verifyCode: (eml_adr: string, code: string) =>
+    apiFetch<unknown>("/user/auth/verify-code/", {
+      method: "POST",
+      body: { eml_adr, code },
+    }),
+
+  googleVerify: (id_token: string) =>
+    apiFetch<LoginResponse>("/user/auth/google/verify/", {
+      method: "POST",
+      body: { id_token },
+    }),
+
+  logout: (device_id: string) =>
+    apiFetch<unknown>("/user/logout/", {
+      method: "POST",
+      body: { device_id },
+      auth: true,
+    }),
+};
+
+export const extractTokens = (
+  res: LoginResponse,
+): { access: string | null; refresh: string | null } => ({
+  access: res.access_token ?? res.access ?? null,
+  refresh: res.refresh_token ?? res.refresh ?? null,
+});

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { AuthUser } from "@/services/auth-service";
+import { tokenStorage } from "@/lib/auth/storage";
+
+type AuthState = {
+  user: AuthUser | null;
+  accessToken: string | null;
+  setSession: (params: {
+    user: AuthUser | null;
+    accessToken: string;
+    refreshToken?: string;
+  }) => void;
+  setUser: (user: AuthUser | null) => void;
+  clearSession: () => void;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      accessToken: null,
+      setSession: ({ user, accessToken, refreshToken }) => {
+        tokenStorage.setTokens(accessToken, refreshToken);
+        set({ user, accessToken });
+      },
+      setUser: (user) => set({ user }),
+      clearSession: () => {
+        tokenStorage.clear();
+        set({ user: null, accessToken: null });
+      },
+    }),
+    {
+      name: "nw_auth_store",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        user: state.user,
+        accessToken: state.accessToken,
+      }),
+    },
+  ),
+);
+
+export const useIsAuthenticated = (): boolean =>
+  useAuthStore((state) => Boolean(state.accessToken));

--- a/stores/ui-store.ts
+++ b/stores/ui-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+type UIState = {
+  isMembershipOpen: boolean;
+  isAuthOpen: boolean;
+  openMembership: () => void;
+  closeMembership: () => void;
+  openAuth: () => void;
+  closeAuth: () => void;
+};
+
+export const useUIStore = create<UIState>((set) => ({
+  isMembershipOpen: false,
+  isAuthOpen: false,
+  openMembership: () => set({ isMembershipOpen: true }),
+  closeMembership: () => set({ isMembershipOpen: false }),
+  openAuth: () => set({ isAuthOpen: true }),
+  closeAuth: () => set({ isAuthOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- 회의 안건이었던 **\"로그인 이후 토큰 관리\"** 문제 해소. 진단 결과 토큰 관리뿐 아니라 인증 시스템 전체가 UI 껍데기 상태였고, Swagger(`https://api.ninewinit.store/swagger/`) 기반으로 처음부터 끝까지 연결.
- 결정사항: **localStorage + Bearer 헤더**, **Zustand**, UI 라벨 \"아이디\" → \"이메일\" (백엔드 `eml_adr` 정렬).

## 변경 내용

### 인증 인프라 (신규)
- \`lib/api-client.ts\` — fetch wrapper, Authorization Bearer 자동 첨부, **401 발생 시 `/user/login/refresh/`로 access_token 재발급 후 원 요청 1회 자동 재시도**, in-flight refresh 중복 호출 방지
- \`lib/auth/storage.ts\` — localStorage 키 상수(`nw_access_token`, `nw_refresh_token`, `nw_device_id`), safe read/write, device_id 자동 생성(`crypto.randomUUID`)
- \`stores/auth-store.ts\` — Zustand + `persist` 미들웨어, `user`/`accessToken` 영속화
- \`services/auth-service.ts\` — 7개 엔드포인트 타입 안전 호출
- \`schemas/auth-schemas.ts\` — zod 스키마 (login / signup email / verify code / signup details)
- \`hooks/use-auth.ts\` — `useLoginMutation`, `useSendCodeMutation`, `useVerifyCodeMutation`, `useSignupMutation`, `useGoogleLoginMutation`, `useLogoutMutation`
- \`app/providers.tsx\` — QueryClientProvider + GoogleOAuthProvider + sonner Toaster
- \`app/layout.tsx\` — `<Providers>`로 children 래핑

### UI 연동
- \`components/modal/login-modal.tsx\` — react-hook-form + zod, \"이메일\" 라벨, 에러 메시지, 로딩 상태, Google 로그인 버튼 연결
- \`components/modal/signup-modal.tsx\` — **3-step 이메일 인증 흐름** (이메일 → 코드 → 비번/이름/전화)
- \`components/auth/google-login-button.tsx\` — `@react-oauth/google` id_token 발급 후 `/user/auth/google/verify/` 호출
- \`components/auth/route-guard.tsx\` — 클라이언트 라우트 가드, hydration 완료 후 인증 체크 → 비로그인 시 홈으로 redirect
- \`components/header.tsx\` — 로그인 상태에 따라 \"로그인\" ↔ \"로그아웃\" 토글
- \`components/mypage/mypage-menu.tsx\` — Logout 버튼 onClick 연결 (이전엔 onClick 없음)
- \`components/mypage/user-profile.tsx\` — \"Username\"/\"user@example.com\" 하드코딩 제거, store에서 실제 사용자 정보 표시
- \`app/mypage/page.tsx\` — `<RouteGuard>`로 보호

### 정리
- \`recoil/auth.ts\` 삭제 — recoil 미설치 상태에서의 dead code (#6 Close)
- \`.env.example\` 추가 — `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
- \`.gitignore\` — `.env.example` 예외 허용

### 의존성
- 추가: `zustand`, `@react-oauth/google`
- 활용 시작: `@tanstack/react-query`, `react-hook-form`, `@hookform/resolvers`, `zod`, `sonner` (설치돼 있었으나 미사용 상태)

## Swagger 엔드포인트 매핑

| 메서드 | 경로 | 사용처 |
|---|---|---|
| POST | `/user/auth/login/` | LoginModal |
| POST | `/user/auth/signup/` | SignUpModal step3 |
| POST | `/user/auth/send-code/` | SignUpModal step1 |
| POST | `/user/auth/verify-code/` | SignUpModal step2 |
| POST | `/user/auth/google/verify/` | GoogleLoginButton |
| POST | `/user/login/refresh/` | api-client 401 인터셉터 |
| POST | `/user/logout/` | Header / mypage Logout |

> 로그인/회원가입 응답의 토큰 키 이름이 drf-yasg Swagger 한계로 명확하지 않아 `access_token`/`access` 양쪽 모두 지원하도록 구현 (\`extractTokens\` 헬퍼). 실제 응답을 보고 단순화 가능.

## 본 PR 범위에서 명시적으로 제외 (다른 이슈로 분리)
- next.config.mjs ignore 플래그 제거 → #5
- 문의 폼 리팩터 → #9
- error.tsx / not-found.tsx → #10
- next/image 마이그레이션 → #13
- middleware.ts SSR 가드 (cookie 도입과 함께 후속)

## Test plan
- [ ] `.env.local`에 `NEXT_PUBLIC_API_BASE_URL=https://api.ninewinit.store` 와 (선택) `NEXT_PUBLIC_GOOGLE_CLIENT_ID` 설정
- [ ] `npm run dev` 후 홈에서 로그인 모달 → 잘못된 비밀번호 → 빨간 토스트
- [ ] 정상 로그인 → 토스트 + 모달 닫힘 + Header가 \"로그아웃\"으로 변경
- [ ] DevTools Application 탭에서 `nw_access_token`, `nw_refresh_token`, `nw_device_id` localStorage 저장 확인
- [ ] 회원가입 3-step 흐름: 이메일 입력 → 코드 발송 토스트 → 이메일에서 코드 확인 → 코드 입력 → 비번/이름 입력 → 가입 완료 후 자동 로그인
- [ ] 로그아웃 상태로 `/mypage` 직접 진입 → 홈으로 리다이렉트
- [ ] 로그인 상태로 `/mypage` 진입 → UserProfile에 본인 정보 표시
- [ ] DevTools에서 `nw_access_token`을 일부러 망가뜨린 후 보호 API 호출 → refresh 인터셉터가 동작해서 새 토큰 발급 + 재시도 성공
- [ ] mypage Logout 버튼 → 토스트 + localStorage clear + 홈 이동
- [ ] `npm run build` 0 에러로 통과
- [ ] `npx tsc --noEmit` 0 에러로 통과
- [ ] Google Client ID 미설정 상태에서 Google 버튼은 자연스럽게 disabled (title에 이유 표시)

Refs #4
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 부수 정리 커밋 추가 (2026-05-23)

테스트 가능 시점이 오늘 저녁 정규 회의 이후이므로, 인증 PR과 자연스럽게 어울리는 저위험 작업들을 같은 브랜치에 추가했습니다.

### 추가 커밋: `chore: 인증 PR 부수 정리`
- **#8** alert/console.log 정리 — `components/main.tsx` 문의 폼 alert() → sonner toast, console.log 제거 (sonner Toaster는 이 PR이 이미 마운트)
- **#10** error/not-found/loading — `app/error.tsx` 신규 (재시도+홈 fallback, dev에서만 메시지 노출), `app/not-found.tsx` 신규, `app/loading.tsx`의 `return null`을 중앙 정렬 스피너로 교체
- **#12** a11y — `components/main/inquiry-section.tsx`의 5개 `<label>`에 `htmlFor` + 대응 input/textarea `id` 매칭, `components/header.tsx` 로고 버튼에 `aria-label="홈으로 이동"`
- **#15** SEO/metadata — `app/layout.tsx`의 `generator: 'v0.dev'` 제거, `app/intro/page.tsx`·`app/mypage/page.tsx`에 `export const metadata` 추가 (mypage는 `robots: index/follow=false`)

### 남은 이슈 (별도 PR로 분리)
- **#5** next.config.mjs ignore 플래그 제거 — 기존 14+개 ESLint 에러가 한꺼번에 드러나므로 단독 PR로 처리
- **#9** 문의 폼 react-hook-form+zod 재작성 — Swagger에 접수 엔드포인트 없어 백엔드 결정 대기
- **#11** "use client" 최소화 — 아키텍처 변경, 별도 PR
- **#13** next/image 마이그레이션 — 레이아웃 시각 확인 필요, 별도 PR
- **#14** 가격·연락처 하드코딩 정리 — 별도 PR
- **#16** Props drilling/컴포넌트 분리 리팩터 — 별도 PR

### 추가 Closes
Closes #8 #10 #12 #15


---

## 추가 작업 2차 (2026-05-23 저녁)

회의 전 백엔드 의존 없이 가능한 작업 4건 추가 흡수.

### `fix(build)` — #5 빌드 안전망 복구
- `next.config.mjs`의 `ignoreBuildErrors`/`ignoreDuringBuilds`/`unoptimized` 3개 플래그 제거
- 드러난 ESLint 에러 14건 수정:
  - `hero-section.tsx`: 6개 인용부호 → `&ldquo;`/`&rdquo;` 엔티티
  - `service-section.tsx`: 미사용 Tooltip 4개 import 제거
  - `ui/calendar.tsx`: IconLeft/IconRight 미사용 props 제거
  - `ui/chart.tsx`: filter 콜백 미사용 `_` → 빈 슬롯
  - `ui/use-toast.ts`, `hooks/use-toast.ts`: 미사용 `actionTypes` const → 순수 타입
- 이제 빌드가 lint/TS 검증을 정상 수행

### `refactor(config)` — #14 부분
- `config/company.ts`: 주소·전화·이메일·사업자번호·대표·카피라이트 연도 등 정적 정보
- `config/pricing.ts`: 멤버십 플랜 3종 (1개월/3개월/1년)
- `footer.tsx`, `pro-modal.tsx`에서 하드코딩 제거 후 config 모듈 사용
- 가격을 백엔드 `/api/subscription/`으로 옮기는 본작업은 후속 PR

### `refactor(forms)` — #9 부분
- `schemas/inquiry-schema.ts`: 5필드 zod 검증
- `components/main.tsx`: `useState` 5개 + 수동 `handleInputChange` → 단일 `useForm`
- `components/main/inquiry-section.tsx`: register 기반 controlled input, 필드별 인라인 에러, aria-invalid, isSubmitting 처리, 필드 메타데이터 배열 추출로 마크업 축소
- submit은 여전히 토스트 — 실제 API 호출은 백엔드 엔드포인트 확정 후 TODO

### `refactor` — #16 큰 컴포넌트 분리 + Props drilling 정리
- `stores/ui-store.ts`: 멤버십·인증 모달 표시 상태를 zustand로 이전
- `ProModal`·`AuthModal`이 props 대신 store 직접 소비, isOpen/onClose props 제거
- Header가 더 이상 `showMembership`·`showAuth` state 보유 안 함
- Main이 더 이상 `setShowMembership`을 ServiceSection으로 prop drilling 안 함
- `components/main/service-section/seo-analysis-panel.tsx` 추출
- `components/main/service-section/service-cta-panel.tsx` 추출
- `service-section.tsx` 119줄 → 41줄

### 추가 Closes
Closes #5 #16

### 남은 이슈 (별도 PR)
- **#9** 본작업 — 백엔드 문의 접수 엔드포인트 확정 후 실제 API 호출 연결
- **#11** "use client" 최소화 — 아키텍처 변경, 별도 PR
- **#13** next/image 마이그레이션 — 시각 확인 필요, 별도 PR
- **#14** 본작업 — 가격을 백엔드로 옮기는 부분
